### PR TITLE
Fix initialization of menu action

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -71,9 +71,9 @@ class MainWindow(QMainWindow):
         self.lang_en_action = lang_en
         self.lang_ru_action = lang_ru
 
+        self.about_action = about_action
         i18n.language_changed.connect(self.retranslate_ui)
         self.retranslate_ui()
-        self.about_action = about_action
 
     def show_about(self):
         QMessageBox.information(self, tr("About"), tr("Объединяй и проверяй\nVersion 2 25.05.2025\nslipfaith"))


### PR DESCRIPTION
## Summary
- ensure `about_action` is created before calling `retranslate_ui`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for PySide6 and openpyxl)*

------
https://chatgpt.com/codex/tasks/task_e_68548daa9708832ca70d8f6fc33d5c4f