### PR TITLE
Fix tab widget setup order

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -12,7 +12,6 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle(tr("xlMerger: объединяй и проверяй"))
         self.setWindowIcon(QIcon(r"C:\Users\yanismik\Desktop\PythonProject1\xlM_2.0\xlM2.0.ico"))  # <- иконка здесь
-        self.init_menu()
 
         # Создаем QTabWidget и добавляем вкладки
         self.tab_widget = QTabWidget()
@@ -30,6 +29,7 @@ class MainWindow(QMainWindow):
         self.tab_widget.addTab(self.split_tab_widget, tr("Разделение"))
 
         self.setCentralWidget(self.tab_widget)
+        self.init_menu()
         self.show()
 
     def retranslate_ui(self):


### PR DESCRIPTION
## Summary
- set up QTabWidget before running menu initialization

This prevents `MainWindow` from failing at startup because `init_menu()` calls `retranslate_ui()` which expects `tab_widget` to exist.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_6857028e73e4832cbd23569534f458d7