### PR TITLE
Improve Excel split tab

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -155,5 +155,10 @@
   "Ячейки: {cells}; Верхний={upper if upper is not None else '—'}, Нижний={lower if lower is not None else '—'}": "Ячейки: {cells}; Верхний={upper if upper is not None else '—'}, Нижний={lower if lower is not None else '—'}",
   "длина = {text_length} (лимит {current_limit})": "длина = {text_length} (лимит {current_limit})",
   "длина = {text_length} (нижний лимит {current_lower})": "длина = {text_length} (нижний лимит {current_lower})",
-  "✔ Готово!": "✔ Done!"
+  "✔ Готово!": "✔ Done!",
+  "Дополнительные столбцы:": "Additional columns:",
+  "Доп": "Extra",
+  "Сохранение...": "Saving...",
+  "Прогресс": "Progress",
+  "Сохраняется: {name}": "Saving: {name}"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -155,5 +155,10 @@
   "Ячейки: {cells}; Верхний={upper if upper is not None else '—'}, Нижний={lower if lower is not None else '—'}": "Ячейки: {cells}; Верхний={upper if upper is not None else '—'}, Нижний={lower if lower is not None else '—'}",
   "длина = {text_length} (лимит {current_limit})": "длина = {text_length} (лимит {current_limit})",
   "длина = {text_length} (нижний лимит {current_lower})": "длина = {text_length} (нижний лимит {current_lower})",
-  "✔ Готово!": "✔ Готово!"
+  "✔ Готово!": "✔ Готово!",
+  "Дополнительные столбцы:": "Дополнительные столбцы:",
+  "Доп": "Доп",
+  "Сохранение...": "Сохранение...",
+  "Прогресс": "Прогресс",
+  "Сохраняется: {name}": "Сохраняется: {name}"
 }


### PR DESCRIPTION
## Summary
- update `split_excel_by_languages` to support extra columns and progress callbacks
- modernize split preview dialog with fixed size and extras selection
- allow selecting entire column range in preview
- show progress when saving and remember extra columns in the split tab
- add translations for new texts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_68570e424bd0832ca0f0265f6e5abf73