### PR TITLE
Fix explicit target columns in splitting

### DIFF
--- a/core/split_excel.py
+++ b/core/split_excel.py
@@ -64,10 +64,12 @@ def split_excel_by_languages(
     for target_lang, idx in header_map.items():
         if target_lang == source_lang:
             continue
-        if target_langs is not None and target_lang not in target_langs:
-            continue
-        if not _is_lang_column(target_lang):
-            continue
+        if target_langs is not None:
+            if target_lang not in target_langs:
+                continue
+        else:
+            if not _is_lang_column(target_lang):
+                continue
         targets.append((target_lang, idx))
 
     extra_idx: List[int] = []

--- a/tests/test_split_excel.py
+++ b/tests/test_split_excel.py
@@ -55,3 +55,24 @@ def test_split_excel_with_targets(tmp_path):
     assert out_de.is_file()
     assert not out_en.exists()
 
+
+def test_split_excel_with_non_language_target(tmp_path):
+    src = tmp_path / "main.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws.append(["ru", "English Text", "Another-Lang", "comment"])
+    ws.append(["hi", "en_val", "other_val", "c1"])
+    wb.save(src)
+    wb.close()
+
+    split_excel_by_languages(
+        str(src),
+        "Sheet1",
+        "ru",
+        target_langs=["English Text"]
+    )
+
+    out_custom = tmp_path / "ru-English Text_main.xlsx"
+    assert out_custom.is_file()
+


### PR DESCRIPTION
## Summary
- handle explicit `target_langs` without filtering by language-like headers
- add regression test for non-language target column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_685710fba5d0832caa78cc2b579bb736