### PR TITLE
Add multi-sheet configuration for splitting

### DIFF
--- a/gui/split_mapping_dialog.py
+++ b/gui/split_mapping_dialog.py
@@ -1,6 +1,14 @@
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QTableView,
-    QListWidget, QListWidgetItem
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QTableView,
+    QListWidget,
+    QListWidgetItem,
+    QComboBox,
+    QListView,
 )
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QStandardItemModel, QStandardItem, QColor, QBrush
@@ -11,40 +19,63 @@ from utils.i18n import tr
 
 
 class SplitMappingDialog(QDialog):
-    """Dialog to select source and target columns using a preview."""
+    """Dialog to select source/target columns for one or many sheets."""
 
-    def __init__(self, excel_path: str, sheet_name: str, parent=None):
+    def __init__(self, excel_path: str, sheet_names, parent=None):
         super().__init__(parent)
+        if isinstance(sheet_names, str):
+            sheet_names = [sheet_names]
         self.excel_path = excel_path
-        self.sheet_name = sheet_name
-        self.headers: list[str] = []
-        self.model = QStandardItemModel()
+        self.sheet_names = sheet_names
+        self.current_sheet = sheet_names[0]
+
+        self.headers_map: dict[str, list[str]] = {}
+        self.models: dict[str, QStandardItemModel] = {}
+        self.configs = {
+            name: {"src": None, "targets": set(), "extra": set()}
+            for name in sheet_names
+        }
+
         self.source_col: int | None = None
         self.target_cols: set[int] = set()
         self.extra_cols: set[int] = set()
-        self._load_preview()
+
+        self._load_all_previews()
         self._init_ui()
 
-    def _load_preview(self):
+    def _load_all_previews(self):
         wb = load_workbook(self.excel_path, read_only=True)
-        sheet = wb[self.sheet_name]
-        self.headers = [
-            str(cell.value) if cell.value is not None else ""
-            for cell in next(sheet.iter_rows(min_row=1, max_row=1))
-        ]
-        self.model.setHorizontalHeaderLabels(self.headers)
-        rows = list(sheet.iter_rows(min_row=2, max_row=11, values_only=True))
-        for row in rows:
-            items = [
-                QStandardItem(str(cell)) if cell is not None else QStandardItem("")
-                for cell in row
+        for name in self.sheet_names:
+            sheet = wb[name]
+            headers = [
+                str(cell.value) if cell.value is not None else ""
+                for cell in next(sheet.iter_rows(min_row=1, max_row=1))
             ]
-            self.model.appendRow(items)
+            model = QStandardItemModel()
+            model.setHorizontalHeaderLabels(headers)
+            rows = list(sheet.iter_rows(min_row=2, max_row=11, values_only=True))
+            for row in rows:
+                items = [
+                    QStandardItem(str(cell)) if cell is not None else QStandardItem("")
+                    for cell in row
+                ]
+                model.appendRow(items)
+            self.headers_map[name] = headers
+            self.models[name] = model
         wb.close()
+        self.model = self.models[self.current_sheet]
+        self.headers = self.headers_map[self.current_sheet]
 
     def _init_ui(self):
         self.setWindowTitle(tr("Настройка разделения"))
         layout = QVBoxLayout(self)
+
+        if len(self.sheet_names) > 1:
+            self.sheet_combo = QComboBox()
+            self.sheet_combo.addItems(self.sheet_names)
+            self.sheet_combo.currentTextChanged.connect(self.switch_sheet)
+            layout.addWidget(self.sheet_combo)
+
         info = QLabel(tr("Выбери исходный столбец (синий) и столбцы перевода (зелёный)."))
         info.setWordWrap(True)
         layout.addWidget(info)
@@ -63,6 +94,9 @@ class SplitMappingDialog(QDialog):
 
         layout.addWidget(QLabel(tr("Дополнительные столбцы:")))
         self.extra_list = QListWidget()
+        self.extra_list.setFlow(QListView.LeftToRight)
+        self.extra_list.setWrapping(True)
+        self.extra_list.setMaximumHeight(80)
         for h in self.headers:
             item = QListWidgetItem(h)
             item.setCheckState(Qt.Unchecked)
@@ -70,7 +104,11 @@ class SplitMappingDialog(QDialog):
         self.extra_list.itemChanged.connect(self.update_label)
         layout.addWidget(self.extra_list)
 
+        self.count_label = QLabel()
+        layout.addWidget(self.count_label)
+
         self.current_label = QLabel()
+        self.current_label.setWordWrap(True)
         layout.addWidget(self.current_label)
 
         btn_layout = QHBoxLayout()
@@ -86,6 +124,38 @@ class SplitMappingDialog(QDialog):
         self.update_label()
         self.resize(700, 500)
         self.setFixedSize(self.size())
+
+    def _save_current(self):
+        cfg = self.configs[self.current_sheet]
+        cfg["src"] = self.source_col
+        cfg["targets"] = set(self.target_cols)
+        cfg["extra"] = set(self.extra_cols)
+
+    def switch_sheet(self, name: str):
+        self._save_current()
+        self.current_sheet = name
+        self.model = self.models[name]
+        self.headers = self.headers_map[name]
+        self.table.setModel(self.model)
+        cfg = self.configs[name]
+        self.source_col = cfg["src"]
+        self.target_cols = set(cfg["targets"])
+        self.extra_cols = set(cfg["extra"])
+        self._rebuild_extra_list()
+        self.update_colors()
+        self.update_label()
+
+    def _rebuild_extra_list(self):
+        self.extra_list.blockSignals(True)
+        self.extra_list.clear()
+        for idx, h in enumerate(self.headers):
+            item = QListWidgetItem(h)
+            if idx in self.extra_cols:
+                item.setCheckState(Qt.Checked)
+            else:
+                item.setCheckState(Qt.Unchecked)
+            self.extra_list.addItem(item)
+        self.extra_list.blockSignals(False)
 
     def handle_drag(self, selection: set[int]):
         start = getattr(self.header_view, "_drag_start", None)
@@ -143,18 +213,28 @@ class SplitMappingDialog(QDialog):
     def update_label(self):
         self._collect_extras()
         if self.source_col is None:
-            txt = f"{tr('Источник')}: —; {tr('Цели')}: —; {tr('Доп')}: —"
+            txt = f"{tr('Источник')}: —\n{tr('Цели')}: —\n{tr('Доп')}: —"
         else:
             src = self.headers[self.source_col]
             tgts = [self.headers[c] for c in sorted(self.target_cols)] if self.target_cols else ['—']
             extras = [self.headers[c] for c in sorted(self.extra_cols)] if self.extra_cols else ['—']
-            txt = f"{tr('Источник')}: {src}; {tr('Цели')}: {', '.join(tgts)}; {tr('Доп')}: {', '.join(extras)}"
-        self.current_label.setText(tr("Текущая настройка: {txt}").format(txt=txt))
+            txt = (
+                f"{tr('Источник')}: {src}\n"
+                f"{tr('Цели')}: {', '.join(tgts)}\n"
+                f"{tr('Доп')}: {', '.join(extras)}"
+            )
+        self.count_label.setText(tr("Выбрано целей: {n}").format(n=len(self.target_cols)))
+        self.current_label.setText(tr("Текущая настройка:\n{txt}").format(txt=txt))
 
     def get_selection(self):
-        if self.source_col is None:
-            return None, [], []
-        source = self.headers[self.source_col]
-        targets = [self.headers[c] for c in sorted(self.target_cols)]
-        extras = [self.headers[c] for c in sorted(self.extra_cols)]
-        return source, targets, extras
+        self._save_current()
+        result = {}
+        for sheet, cfg in self.configs.items():
+            if cfg["src"] is None:
+                continue
+            headers = self.headers_map[sheet]
+            src = headers[cfg["src"]]
+            tgts = [headers[c] for c in sorted(cfg["targets"])]
+            extras = [headers[c] for c in sorted(cfg["extra"])]
+            result[sheet] = (src, tgts, extras)
+        return result


### PR DESCRIPTION
## Summary
- support configuring split source/target columns for all sheets at once
- modernize UI for extra columns and show a target counter
- update split tab to process multiple configured sheets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_68572ad874a0832ca9be0bc882d8ff22