### PR TITLE
Fix sheet preview loading and style drag-drop field

### DIFF
--- a/core/drag_drop.py
+++ b/core/drag_drop.py
@@ -12,6 +12,19 @@ class DragDropLineEdit(QLineEdit):
         self.setAcceptDrops(True)
         self.setReadOnly(True)
         self.mode = mode  # 'files_or_folder' или 'file'
+        self.setStyleSheet(
+            """
+            QLineEdit {
+                border: 2px dashed #aaa;
+                border-radius: 6px;
+                padding: 6px;
+                background: #fafafa;
+            }
+            QLineEdit:hover {
+                background: #f0f0f0;
+            }
+            """
+        )
 
     def dragEnterEvent(self, event):
         if event.mimeData().hasUrls():

--- a/gui/split_mapping_dialog.py
+++ b/gui/split_mapping_dialog.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QStandardItemModel, QStandardItem, QColor, QBrush
 from openpyxl import load_workbook
+from itertools import islice
 
 from gui.limits_checker import DraggableHeaderView
 from utils.i18n import tr
@@ -65,7 +66,7 @@ class SplitMappingDialog(QDialog):
                 model.appendRow(items)
             # detect non-empty columns (look over first 30 rows)
             non_empty = set()
-            rows_for_check = list(sheet.iter_rows(min_row=2, max_row=min(sheet.max_row, 30), values_only=True))
+            rows_for_check = list(islice(sheet.iter_rows(min_row=2, values_only=True), 30))
             if rows_for_check:
                 for idx, col in enumerate(zip(*rows_for_check)):
                     if any(v not in (None, "") for v in col):


### PR DESCRIPTION
## Summary
- avoid using `sheet.max_row` for read-only sheets when loading preview
- restyle `DragDropLineEdit` with a modern dashed border

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_685731d332d4832c8b8529e6f6efbf41