### PR TITLE
Fix splitter tab style and extra column selection

### DIFF
--- a/gui/split_mapping_dialog.py
+++ b/gui/split_mapping_dialog.py
@@ -249,8 +249,10 @@ class SplitMappingDialog(QDialog):
                     self.extra_cols.add(col_idx)
 
     def update_label(self):
-        self._rebuild_extra_list()
+        # first collect states from the current list
         self._collect_extras()
+        # rebuild list to reflect current source/target selections
+        self._rebuild_extra_list()
         if self.source_col is None:
             txt = f"{tr('Источник')}: —\n{tr('Цели')}: —\n{tr('Доп')}: —"
         else:

--- a/gui/split_tab.py
+++ b/gui/split_tab.py
@@ -53,16 +53,11 @@ class SplitTab(QWidget):
 
         layout.addLayout(right)
 
+        # minimal styling for buttons and widgets
         self.setStyleSheet(
             """
             QWidget {font-size: 14px;}
-            QPushButton {
-                padding: 8px 16px;
-                border-radius: 8px;
-                background: #2196F3;
-                color: white;
-            }
-            QPushButton:hover {background: #1976D2;}
+            QPushButton {padding: 6px 12px; border-radius: 4px;}
             QLineEdit {font-size:14px;}
             """
         )


### PR DESCRIPTION
## Summary
- simplify button styling in the splitter tab
- keep extra column selections when choosing source/target columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_685740bfa484832cb79c257720c5f81b