### PR TITLE
Make SplitTab font match other tabs

### DIFF
--- a/gui/split_tab.py
+++ b/gui/split_tab.py
@@ -53,13 +53,7 @@ class SplitTab(QWidget):
 
         layout.addLayout(right)
 
-        # minimal styling for buttons and widgets
-        self.setStyleSheet(
-            """
-            QWidget {font-size: 14px;}
-            QLineEdit {font-size:14px;}
-            """
-        )
+        # Use application defaults for styling to match other tabs
 
     def on_file_selected(self, path):
         """Store selected Excel path and reset mappings."""


### PR DESCRIPTION
## Summary
- remove hardcoded font sizing from `SplitTab`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_6859ca9fee20832c86bb1dee875e346b