### PR TITLE
Fix validation for copy column input

### DIFF
--- a/core/main_page_logic.py
+++ b/core/main_page_logic.py
@@ -122,6 +122,9 @@ class MainPageLogic(QObject):
         if not excel_file_path or not os.path.isfile(excel_file_path):
             QMessageBox.critical(self.ui, "Ошибка", "Указанный файл Excel не существует.")
             return False
+        if not copy_column:
+            QMessageBox.critical(self.ui, "Ошибка", "Укажи столбец для копирования.")
+            return False
         if not selected_sheets:
             QMessageBox.critical(self.ui, "Ошибка", "Выбери хотя бы один лист.")
             return False


### PR DESCRIPTION
## Summary
- ensure `MainPageLogic.validate_inputs` verifies the copy column entry is filled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_6862ee8c1210832cb7a6dad2e9bcc975