### PR TITLE
Enable multi-file drag-and-drop in merge tab

### DIFF
--- a/gui/merge_tab.py
+++ b/gui/merge_tab.py
@@ -71,6 +71,11 @@ class MergeTab(QWidget):
         self.main_file_input.setPlaceholderText(tr("Общий Excel"))
         layout.addWidget(self.main_file_input)
 
+        self.sources_input = DragDropLineEdit(mode='files_or_folder')
+        self.sources_input.setPlaceholderText(tr("Файлы источников"))
+        self.sources_input.filesSelected.connect(self.add_rows_from_files)
+        layout.addWidget(self.sources_input)
+
         self.mappings_layout = QVBoxLayout()
         layout.addLayout(self.mappings_layout)
 
@@ -86,15 +91,22 @@ class MergeTab(QWidget):
         layout.addWidget(merge_btn)
         self.merge_btn = merge_btn
 
-    def add_row(self):
+    def add_row(self, file_path: str | None = None):
         row = MappingRow(self)
         row.remove_btn.clicked.connect(lambda: self.remove_row(row))
         self.mappings_layout.addWidget(row)
         self.rows.append(row)
+        if file_path:
+            row.file_input.setText(file_path)
+        return row
 
     def remove_row(self, row: MappingRow):
         row.setParent(None)
         self.rows.remove(row)
+
+    def add_rows_from_files(self, files: List[str]):
+        for f in files:
+            self.add_row(f)
 
     def run_merge(self):
         main_file = self.main_file_input.text()
@@ -118,6 +130,7 @@ class MergeTab(QWidget):
 
     def retranslate_ui(self):
         self.main_file_input.setPlaceholderText(tr("Общий Excel"))
+        self.sources_input.setPlaceholderText(tr("Файлы источников"))
         self.add_btn.setText(tr("Добавить источник"))
         self.merge_btn.setText(tr("Объединить"))
         for r in self.rows:

--- a/tests/test_merge_tab.py
+++ b/tests/test_merge_tab.py
@@ -1,0 +1,27 @@
+import sys
+import pytest
+
+pytest.importorskip("PySide6.QtWidgets")
+from PySide6.QtWidgets import QApplication
+
+from gui.merge_tab import MergeTab
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(sys.argv)
+    return app
+
+
+def test_add_rows_from_files(qapp, tmp_path):
+    tab = MergeTab()
+    files = []
+    for i in range(2):
+        p = tmp_path / f"f{i}.xlsx"
+        p.write_text("")
+        files.append(str(p))
+    tab.add_rows_from_files(files)
+    assert len(tab.rows) == 2
+    assert [row.file_input.text() for row in tab.rows] == files


### PR DESCRIPTION
## Summary
- add a bulk source files drop area to merge tab
- support adding rows for each dropped file
- test multiple file addition behaviour

## Testing
- `PYTHONPATH=. pytest tests/test_merge_tab.py tests/test_merge_columns.py tests/test_split_excel.py tests/test_limits.py`
- `apt-get install -y libgl1` *(fails: Unable to locate package libgl1)*

------
https://chatgpt.com/codex/tasks/task_e_688e74e4d0d4832ca2516998e8f93db6