### PR TITLE
Move merge mapping settings into its own dialog

### DIFF
--- a/gui/merge_mapping_dialog.py
+++ b/gui/merge_mapping_dialog.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import List
+
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QWidget,
+    QLineEdit
+)
+
+from utils.i18n import tr, i18n
+from core.drag_drop import DragDropLineEdit
+
+
+class MappingRow(QWidget):
+    def __init__(self, parent: QWidget | None = None):
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setSpacing(10)
+
+        self.file_input = DragDropLineEdit(mode='file')
+        self.file_input.setPlaceholderText(tr("Файл источник"))
+        layout.addWidget(self.file_input)
+
+        self.src_cols = QLineEdit()
+        self.src_cols.setPlaceholderText(tr("Колонки источника"))
+        layout.addWidget(self.src_cols)
+
+        self.target_sheet = QLineEdit()
+        self.target_sheet.setPlaceholderText(tr("Лист назначения"))
+        layout.addWidget(self.target_sheet)
+
+        self.target_cols = QLineEdit()
+        self.target_cols.setPlaceholderText(tr("Колонки назначения"))
+        layout.addWidget(self.target_cols)
+
+        self.remove_btn = QPushButton("✕")
+        layout.addWidget(self.remove_btn)
+
+    def get_mapping(self):
+        src = self.file_input.text()
+        src_cols = [c.strip() for c in self.src_cols.text().split(',') if c.strip()]
+        tgt_sheet = self.target_sheet.text().strip()
+        tgt_cols = [c.strip() for c in self.target_cols.text().split(',') if c.strip()]
+        return {
+            'source': src,
+            'source_columns': src_cols,
+            'target_sheet': tgt_sheet,
+            'target_columns': tgt_cols,
+        }
+
+    def retranslate(self):
+        self.file_input.setPlaceholderText(tr("Файл источник"))
+        self.src_cols.setPlaceholderText(tr("Колонки источника"))
+        self.target_sheet.setPlaceholderText(tr("Лист назначения"))
+        self.target_cols.setPlaceholderText(tr("Колонки назначения"))
+
+
+class MergeMappingDialog(QDialog):
+    """Dialog for configuring column mappings for multiple source files."""
+
+    def __init__(self, parent: QWidget | None = None):
+        super().__init__(parent)
+        self.rows: List[MappingRow] = []
+        self.setWindowTitle(tr("Настройки сопоставления"))
+        layout = QVBoxLayout(self)
+
+        self.mappings_layout = QVBoxLayout()
+        layout.addLayout(self.mappings_layout)
+
+        add_btn = QPushButton(tr("Добавить источник"))
+        add_btn.clicked.connect(self.add_row)
+        layout.addWidget(add_btn)
+        self.add_btn = add_btn
+
+        btn_layout = QHBoxLayout()
+        ok_btn = QPushButton(tr("Готово"))
+        cancel_btn = QPushButton(tr("Отмена"))
+        ok_btn.clicked.connect(self.accept)
+        cancel_btn.clicked.connect(self.reject)
+        btn_layout.addStretch()
+        btn_layout.addWidget(ok_btn)
+        btn_layout.addWidget(cancel_btn)
+        layout.addLayout(btn_layout)
+        self.ok_btn = ok_btn
+        self.cancel_btn = cancel_btn
+
+        i18n.language_changed.connect(self.retranslate_ui)
+        self.retranslate_ui()
+
+    def add_row(self, file_path: str | None = None):
+        row = MappingRow(self)
+        row.remove_btn.clicked.connect(lambda: self.remove_row(row))
+        self.mappings_layout.addWidget(row)
+        self.rows.append(row)
+        if file_path:
+            row.file_input.setText(file_path)
+        return row
+
+    def remove_row(self, row: MappingRow):
+        row.setParent(None)
+        self.rows.remove(row)
+
+    def get_mappings(self):
+        mappings = []
+        for row in self.rows:
+            mp = row.get_mapping()
+            if mp['source'] and mp['source_columns'] and mp['target_sheet'] and mp['target_columns']:
+                mappings.append(mp)
+        return mappings
+
+    def retranslate_ui(self):
+        self.setWindowTitle(tr("Настройки сопоставления"))
+        self.add_btn.setText(tr("Добавить источник"))
+        self.ok_btn.setText(tr("Готово"))
+        self.cancel_btn.setText(tr("Отмена"))
+        for r in self.rows:
+            r.retranslate()

--- a/gui/merge_tab.py
+++ b/gui/merge_tab.py
@@ -1,64 +1,22 @@
 from __future__ import annotations
 
 from typing import List
+import os
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QMessageBox, QLineEdit
+    QWidget, QVBoxLayout, QPushButton, QMessageBox
 )
 
 from utils.i18n import tr, i18n
 from core.drag_drop import DragDropLineEdit
 from core.merge_columns import merge_excel_columns
-
-
-class MappingRow(QWidget):
-    def __init__(self, parent: QWidget | None = None):
-        super().__init__(parent)
-        layout = QHBoxLayout(self)
-        layout.setSpacing(10)
-
-        self.file_input = DragDropLineEdit(mode='file')
-        self.file_input.setPlaceholderText(tr("Файл источник"))
-        layout.addWidget(self.file_input)
-
-        self.src_cols = QLineEdit()
-        self.src_cols.setPlaceholderText(tr("Колонки источника"))
-        layout.addWidget(self.src_cols)
-
-        self.target_sheet = QLineEdit()
-        self.target_sheet.setPlaceholderText(tr("Лист назначения"))
-        layout.addWidget(self.target_sheet)
-
-        self.target_cols = QLineEdit()
-        self.target_cols.setPlaceholderText(tr("Колонки назначения"))
-        layout.addWidget(self.target_cols)
-
-        self.remove_btn = QPushButton("✕")
-        layout.addWidget(self.remove_btn)
-
-    def get_mapping(self):
-        src = self.file_input.text()
-        src_cols = [c.strip() for c in self.src_cols.text().split(',') if c.strip()]
-        tgt_sheet = self.target_sheet.text().strip()
-        tgt_cols = [c.strip() for c in self.target_cols.text().split(',') if c.strip()]
-        return {
-            'source': src,
-            'source_columns': src_cols,
-            'target_sheet': tgt_sheet,
-            'target_columns': tgt_cols,
-        }
-
-    def retranslate(self):
-        self.file_input.setPlaceholderText(tr("Файл источник"))
-        self.src_cols.setPlaceholderText(tr("Колонки источника"))
-        self.target_sheet.setPlaceholderText(tr("Лист назначения"))
-        self.target_cols.setPlaceholderText(tr("Колонки назначения"))
+from .merge_mapping_dialog import MergeMappingDialog
 
 
 class MergeTab(QWidget):
     def __init__(self):
         super().__init__()
-        self.rows: List[MappingRow] = []
+        self.source_files: List[str] = []
         self.init_ui()
         i18n.language_changed.connect(self.retranslate_ui)
         self.retranslate_ui()
@@ -73,16 +31,9 @@ class MergeTab(QWidget):
 
         self.sources_input = DragDropLineEdit(mode='files_or_folder')
         self.sources_input.setPlaceholderText(tr("Файлы источников"))
-        self.sources_input.filesSelected.connect(self.add_rows_from_files)
+        self.sources_input.filesSelected.connect(self.handle_files_selected)
+        self.sources_input.folderSelected.connect(self.handle_folder_selected)
         layout.addWidget(self.sources_input)
-
-        self.mappings_layout = QVBoxLayout()
-        layout.addLayout(self.mappings_layout)
-
-        add_btn = QPushButton(tr("Добавить источник"))
-        add_btn.clicked.connect(self.add_row)
-        layout.addWidget(add_btn)
-        self.add_btn = add_btn
 
         layout.addStretch()
 
@@ -91,47 +42,43 @@ class MergeTab(QWidget):
         layout.addWidget(merge_btn)
         self.merge_btn = merge_btn
 
-    def add_row(self, file_path: str | None = None):
-        row = MappingRow(self)
-        row.remove_btn.clicked.connect(lambda: self.remove_row(row))
-        self.mappings_layout.addWidget(row)
-        self.rows.append(row)
-        if file_path:
-            row.file_input.setText(file_path)
-        return row
+    def handle_files_selected(self, files: List[str]):
+        self.source_files = files
 
-    def remove_row(self, row: MappingRow):
-        row.setParent(None)
-        self.rows.remove(row)
-
-    def add_rows_from_files(self, files: List[str]):
-        for f in files:
-            self.add_row(f)
+    def handle_folder_selected(self, folder: str):
+        excel_exts = ('.xlsx', '.xls')
+        if os.path.isdir(folder):
+            self.source_files = [
+                os.path.join(folder, f)
+                for f in os.listdir(folder)
+                if f.lower().endswith(excel_exts)
+            ]
+        else:
+            self.source_files = []
 
     def run_merge(self):
         main_file = self.main_file_input.text()
         if not main_file:
             QMessageBox.critical(self, tr("Ошибка"), tr("Укажи общий Excel."))
             return
+        if not self.source_files:
+            QMessageBox.critical(self, tr("Ошибка"), tr("Укажи файлы источников."))
+            return
 
-        mappings = []
-        for row in self.rows:
-            mp = row.get_mapping()
-            if not (mp['source'] and mp['source_columns'] and mp['target_sheet'] and mp['target_columns']):
-                QMessageBox.critical(self, tr("Ошибка"), tr("Заполни все поля."))
-                return
-            mappings.append(mp)
-
-        try:
-            output = merge_excel_columns(main_file, mappings)
-            QMessageBox.information(self, tr("Успех"), tr("Файл сохранён: {output}").format(output=output))
-        except Exception as e:
-            QMessageBox.critical(self, tr("Ошибка"), str(e))
+        dialog = MergeMappingDialog(self)
+        for f in self.source_files:
+            dialog.add_row(f)
+        if dialog.exec():
+            mappings = dialog.get_mappings()
+            try:
+                output = merge_excel_columns(main_file, mappings)
+                QMessageBox.information(
+                    self, tr("Успех"), tr("Файл сохранён: {output}").format(output=output)
+                )
+            except Exception as e:
+                QMessageBox.critical(self, tr("Ошибка"), str(e))
 
     def retranslate_ui(self):
         self.main_file_input.setPlaceholderText(tr("Общий Excel"))
         self.sources_input.setPlaceholderText(tr("Файлы источников"))
-        self.add_btn.setText(tr("Добавить источник"))
         self.merge_btn.setText(tr("Объединить"))
-        for r in self.rows:
-            r.retranslate()

--- a/tests/test_merge_tab.py
+++ b/tests/test_merge_tab.py
@@ -15,13 +15,12 @@ def qapp():
     return app
 
 
-def test_add_rows_from_files(qapp, tmp_path):
+def test_handle_files_selected(qapp, tmp_path):
     tab = MergeTab()
     files = []
     for i in range(2):
         p = tmp_path / f"f{i}.xlsx"
         p.write_text("")
         files.append(str(p))
-    tab.add_rows_from_files(files)
-    assert len(tab.rows) == 2
-    assert [row.file_input.text() for row in tab.rows] == files
+    tab.handle_files_selected(files)
+    assert tab.source_files == files


### PR DESCRIPTION
## Summary
- Simplify Merge tab to only show main and source Excel inputs with a merge button
- Add standalone dialog for mapping source columns to target sheets/columns
- Adjust tests for new MergeTab API

## Testing
- `PYTHONPATH=. pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688e7f6c798c832ca1803accc5bcb4a5