### PR TITLE
feat: centralize version management

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,5 @@
-__version__ = "1.1"
+from utils import PREVIOUS_VERSION, CURRENT_VERSION
+
+__version__ = CURRENT_VERSION
+
+__all__ = ["__version__", "PREVIOUS_VERSION", "CURRENT_VERSION"]

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -2,6 +2,7 @@ from PySide6.QtWidgets import QMainWindow, QMessageBox, QTabWidget
 from PySide6.QtGui import QAction
 from utils.i18n import tr, i18n
 from utils.updater import check_for_update
+from .. import __version__
 
 from .file_processor_app import FileProcessorApp
 from .limits_checker import LimitsChecker
@@ -92,7 +93,10 @@ class MainWindow(QMainWindow):
         self.retranslate_ui()
 
     def show_about(self):
-        QMessageBox.information(self, tr("About"), tr("Объединяй и проверяй\nVersion 2.1 3.08.2025\nslipfaith"))
+        info_text = (
+            f"{tr('Объединяй и проверяй')}\n{tr('Version')} {__version__}\nslipfaith"
+        )
+        QMessageBox.information(self, tr("About"), info_text)
 
     def check_updates(self, auto: bool = False):
         """Check for application updates via GitHub Releases."""

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility helpers and application metadata."""
+
+PREVIOUS_VERSION = "1.0"
+CURRENT_VERSION = "1.1"
+
+__all__ = ["PREVIOUS_VERSION", "CURRENT_VERSION"]


### PR DESCRIPTION
## Summary
- centralize version definitions in utils module and expose via package
- show About dialog with dynamic version

## Testing
- `python -m pytest -q` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688f3194e630832c845e07d1a1225cdd