### PR TITLE
Fix __version__ import

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,9 @@
-from utils import PREVIOUS_VERSION, CURRENT_VERSION
+# Support running as a package or as a script by trying both relative and
+# absolute imports for the ``utils`` module.
+try:
+    from .utils import PREVIOUS_VERSION, CURRENT_VERSION  # type: ignore
+except ImportError:  # pragma: no cover - fallback when executed as script
+    from utils import PREVIOUS_VERSION, CURRENT_VERSION
 
 __version__ = CURRENT_VERSION
 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -2,7 +2,7 @@ from PySide6.QtWidgets import QMainWindow, QMessageBox, QTabWidget
 from PySide6.QtGui import QAction
 from utils.i18n import tr, i18n
 from utils.updater import check_for_update
-from .. import __version__
+from __init__ import __version__
 
 from .file_processor_app import FileProcessorApp
 from .limits_checker import LimitsChecker


### PR DESCRIPTION
## Summary
- avoid top-level relative import by loading version from package root
- make package initialization work when run as module or script

## Testing
- `PYTHONPATH=. pytest -q` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_688f341d57a4832c8870c1f430b3cafd