### PR TITLE
Optimize Excel merge to skip empty rows

### DIFF
--- a/core/merge_columns.py
+++ b/core/merge_columns.py
@@ -48,13 +48,13 @@ def merge_excel_columns(main_file: str, mappings: List[Dict[str, object]], outpu
                 raise KeyError(tgt_sheet)
 
             ws_main = wb_main[tgt_sheet]
-            wb_src = load_workbook(src, read_only=True)
+            wb_src = load_workbook(src, data_only=True)
             ws_src = wb_src.active
 
             for s_col, t_col in zip(src_cols, tgt_cols):
-                max_row = max(ws_src.max_row, ws_main.max_row)
-                for row in range(1, max_row + 1):
-                    ws_main[f"{t_col}{row}"].value = ws_src[f"{s_col}{row}"].value
+                for cell in ws_src[s_col]:
+                    if cell.value is not None:
+                        ws_main[f"{t_col}{cell.row}"] = cell.value
             wb_src.close()
 
             if progress_callback:

--- a/tests/test_merge_columns.py
+++ b/tests/test_merge_columns.py
@@ -33,3 +33,36 @@ def test_merge_excel_columns(tmp_path):
     result = [ws[f"B{i}"].value for i in range(1, 4)]
     assert result == ["x", "y", "z"]
     wb.close()
+
+
+def test_merge_excel_columns_skips_empty_rows(tmp_path):
+    main_path = tmp_path / "main.xlsx"
+    src_path = tmp_path / "src.xlsx"
+
+    create_wb(main_path, {}, sheet_name="Main")
+    values = [None, "x", None, None, "y", None, "z", "a", "b", "c"]
+    create_wb(src_path, {"A": values})
+
+    mappings = [{
+        "source": str(src_path),
+        "source_columns": ["A"],
+        "target_sheet": "Main",
+        "target_columns": ["B"],
+    }]
+
+    output = merge_excel_columns(str(main_path), mappings)
+    wb = load_workbook(output)
+    ws = wb["Main"]
+
+    assert ws["B2"].value == "x"
+    assert ws["B5"].value == "y"
+    assert ws["B7"].value == "z"
+    assert ws["B8"].value == "a"
+    assert ws["B9"].value == "b"
+    assert ws["B10"].value == "c"
+
+    assert ws["B1"].value is None
+    assert ws["B3"].value is None
+    assert ws["B4"].value is None
+    assert ws["B6"].value is None
+    wb.close()


### PR DESCRIPTION
## Summary
- Only copy populated cells when merging columns to avoid iterating through empty rows
- Load source workbooks in normal mode for accurate row bounds
- Test merge with sparse row data to ensure non-empty cells retain original indices

## Testing
- `pytest -q` *(fails: ModuleNotFoundError / missing libGL.so.1)*
- `PYTHONPATH=. pytest tests/test_merge_columns.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3d698068832c99feab9b72549541