### PR TITLE
feat: add pgpy fallback for update verification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openpyxl
 pandas
 requests
 pyinstaller
+pgpy


### PR DESCRIPTION
## Summary
- verify update signatures via pgpy when available
- fall back to gpg for environments without pgpy
- include pgpy in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pgpy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_688f75bfbbb0832c9cfcf77b13b40dcf