### PR TITLE
refactor: centralize version handling in updater

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,10 +1,8 @@
 # Support running as a package or as a script by trying both relative and
 # absolute imports for the ``utils`` module.
 try:
-    from .utils import PREVIOUS_VERSION, CURRENT_VERSION  # type: ignore
+    from .utils.updater import PREVIOUS_VERSION, CURRENT_VERSION, __version__  # type: ignore
 except ImportError:  # pragma: no cover - fallback when executed as script
-    from utils import PREVIOUS_VERSION, CURRENT_VERSION
-
-__version__ = CURRENT_VERSION
+    from utils.updater import PREVIOUS_VERSION, CURRENT_VERSION, __version__
 
 __all__ = ["__version__", "PREVIOUS_VERSION", "CURRENT_VERSION"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,6 +1,3 @@
-"""Utility helpers and application metadata."""
+"""Utility helpers."""
 
-PREVIOUS_VERSION = "2.1"
-CURRENT_VERSION = "2.2"
-
-__all__ = ["PREVIOUS_VERSION", "CURRENT_VERSION"]
+__all__: list[str] = []


### PR DESCRIPTION
## Summary
- move version metadata into `utils/updater` and import from there
- guard updater GUI helpers when PySide6 is missing

## Testing
- `PYTHONPATH=. pytest tests/test_merge_columns.py -q`
- `PYTHONPATH=. pytest -q` *(fails: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fb7378eb0832ca3ae6515c8ea1ca2