### PR TITLE
Handle empty headers in split mapping dialog

### DIFF
--- a/gui/split_mapping_dialog.py
+++ b/gui/split_mapping_dialog.py
@@ -96,9 +96,18 @@ class SplitMappingDialog(QDialog):
             ]
             model.appendRow(items)
 
-        self.headers_map[sheet_name] = [
-            str(h) if h is not None else "" for h in filtered_headers
-        ]
+        # Store header names for later retrieval. If a column header is empty,
+        # fallback to its column letter so that downstream functions can
+        # reference the column correctly. Previously an empty string was stored
+        # which caused "source column '' not found" errors when splitting files
+        # with a blank first row.
+        names: list[str] = []
+        for i, h in enumerate(filtered_headers):
+            if h is not None and str(h).strip() != "":
+                names.append(str(h))
+            else:
+                names.append(get_column_letter(keep_idx[i] + 1))
+        self.headers_map[sheet_name] = names
         self.models[sheet_name] = model
         self.non_empty_cols[sheet_name] = set(range(len(keep_idx)))
         self._loaded.add(sheet_name)

--- a/tests/test_split_mapping_dialog.py
+++ b/tests/test_split_mapping_dialog.py
@@ -1,0 +1,28 @@
+import pytest
+from openpyxl import Workbook
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+from PySide6.QtWidgets import QApplication
+from gui.split_mapping_dialog import SplitMappingDialog
+
+
+def test_split_mapping_dialog_handles_blank_header(tmp_path):
+    app = QApplication.instance() or QApplication([])
+
+    src = tmp_path / "main.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws.append([None, None])
+    ws.append(["hi", "hello"])
+    wb.save(src)
+    wb.close()
+
+    dialog = SplitMappingDialog(str(src), ["Sheet1"])
+    dialog.source_col = 0
+    dialog.target_cols = {1}
+
+    selection = dialog.get_selection()
+    assert selection == {"Sheet1": ("A", ["B"], [])}
+
+    dialog.close()


### PR DESCRIPTION
## Summary
- use column letters when split mapping dialog encounters empty headers
- add regression test for blank header handling

## Testing
- `PYTHONPATH=$PWD pytest tests/test_split_mapping_dialog.py -q`
- `PYTHONPATH=$PWD pytest tests/test_split_excel.py::test_split_excel_without_header -q`


------
https://chatgpt.com/codex/tasks/task_e_68a99a97ad78832cb3e1a1ceb89ebea4