### PR TITLE
Add detailed logging and fix cell copy bug

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,3 +1,13 @@
+"""Simple logging helper used across the project.
+
+The original implementation only wrote to a file and duplicated messages to the
+root logger as errors.  For debugging from the command line we want the output
+to appear immediately and we also need a convenient way to log arbitrary error
+messages.  This module now prints log messages to the console using the
+``app_logger`` logger and allows ``log_error`` to receive a message first which
+matches how it is used throughout the codebase.
+"""
+
 import logging
 import datetime
 import os
@@ -19,15 +29,25 @@ class Logger:
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         entry = f"[{timestamp}] {message}"
         self.entries.append(entry)
-        logger.error(message)  # <-- вот здесь дублируем в стандартный логгер
+        # also output to the console immediately
+        logger.info(message)
 
     def log_copy(self, sheet, row, col, value):
         msg = f"COPY: {sheet} R{row}C{col} -> {repr(value)}"
         self.log(msg)
 
-    def log_error(self, sheet, row, col, value):
-        msg = f"ERROR: {sheet} R{row}C{col} -> {repr(value)}"
-        self.log(msg)
+    def log_error(self, message, sheet="", row="", col="", value=""):
+        """Log an error message with optional cell context.
+
+        Most call sites simply pass a text description.  Some also provide
+        additional information such as sheet name, row/column or the value that
+        caused the issue.  To support both use‑cases the arguments are optional
+        and the human readable message is placed first.
+        """
+        location = f" {sheet} R{row}C{col} -> {repr(value)}" if any(
+            [sheet, row, col, value]
+        ) else ""
+        self.log(f"ERROR: {message}{location}")
 
     def log_info(self, text):
         self.log(f"INFO: {text}")


### PR DESCRIPTION
## Summary
- log actions to console and allow message-first error logging
- record sheet headers and copy operations with ranges and values
- copy cells individually skipping blanks to avoid clearing existing text

## Testing
- `PYTHONPATH=. pytest tests/test_resolve_column_index.py -q`
- `PYTHONPATH=. pytest tests/test_split_excel.py -q`
- `PYTHONPATH=. pytest tests/test_merge_columns.py -q`
- `PYTHONPATH=. pytest tests/test_limits.py -q`
- `PYTHONPATH=. pytest tests/test_main_page_logic_validation.py -q` *(fails: ImportError: libGL.so.1)*


------
https://chatgpt.com/codex/tasks/task_e_68af90baf5ac832c9719a69e264650b6