### PR TITLE
Improve logging and remove unused processor utils

### DIFF
--- a/core/main_page_logic.py
+++ b/core/main_page_logic.py
@@ -1,11 +1,12 @@
 import os
-import traceback
+
 from PySide6.QtWidgets import QMessageBox, QListWidgetItem
 from PySide6.QtCore import Qt, QObject, Signal
 
 from core.excel_processor import ExcelProcessor
 from gui.excel_previewer import ExcelPreviewer
 from gui.excel_file_selector import ExcelFileSelector
+from utils.logger import logger
 
 class MainPageLogic(QObject):
     proceed_to_next = Signal()  # Сигнал для перехода на следующий шаг
@@ -131,8 +132,4 @@ class MainPageLogic(QObject):
         return True
 
     def log_error(self, error):
-        log_file_path = os.path.join(os.path.dirname(__file__), 'error_log.txt')
-        with open(log_file_path, 'a', encoding='utf-8') as log_file:
-            log_file.write("Ошибка: " + str(error) + "\n")
-            log_file.write(traceback.format_exc())
-            log_file.write("\n")
+        logger.exception("Ошибка: %s", error)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -15,25 +15,25 @@ class Logger:
         self.log_file = log_file
         self.entries = []
 
-    def log(self, message):
+    def log(self, message, level=logging.INFO):
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         entry = f"[{timestamp}] {message}"
         self.entries.append(entry)
-        logger.error(message)  # <-- вот здесь дублируем в стандартный логгер
+        logger.log(level, message)  # Дублируем запись в стандартный логгер
 
     def log_copy(self, sheet, row, col, value):
         msg = f"COPY: {sheet} R{row}C{col} -> {repr(value)}"
-        self.log(msg)
+        self.log(msg, logging.INFO)
 
     def log_error(self, sheet, row, col, value):
         msg = f"ERROR: {sheet} R{row}C{col} -> {repr(value)}"
-        self.log(msg)
+        self.log(msg, logging.ERROR)
 
     def log_info(self, text):
-        self.log(f"INFO: {text}")
+        self.log(f"INFO: {text}", logging.INFO)
 
     def log_warning(self, text):
-        self.log(f"WARNING: {text}")
+        self.log(f"WARNING: {text}", logging.WARNING)
 
     def save(self):
         if not self.entries:


### PR DESCRIPTION
## Summary
- route MainPageLogic errors through the shared logger instead of a local file
- add log level support to the central Logger helper
- delete the unused core/processor_utils module

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'core'; ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c7009ff4a4832c9d92dc4a787891cf