### PR TITLE
Validate translation column input and log cell-level copies

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -21,8 +21,20 @@ class Logger:
         self.entries.append(entry)
         logger.log(level, message)  # Дублируем запись в стандартный логгер
 
-    def log_copy(self, sheet, row, col, value):
-        msg = f"COPY: {sheet} R{row}C{col} -> {repr(value)}"
+    def log_copy(
+        self,
+        source_file,
+        source_sheet,
+        source_cell,
+        target_file,
+        target_sheet,
+        target_cell,
+        value,
+    ):
+        msg = (
+            f"COPY: {source_file} [{source_sheet}!{source_cell}] -> "
+            f"{target_file} [{target_sheet}!{target_cell}] : {repr(value)}"
+        )
         self.log(msg, logging.INFO)
 
     def log_error(self, sheet, row, col, value):


### PR DESCRIPTION
## Summary
- validate translation column input as Excel-style letters and normalize to uppercase
- add explicit error messaging when column letters are invalid
- log copy operations with detailed source and target cell information

## Testing
- python -m pytest -q *(fails: missing libGL dependency in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928ba71efe8832cb6df52254dcf3887)