### PR TITLE
Add markdown copy logger

### DIFF
--- a/core/excel_processor.py
+++ b/core/excel_processor.py
@@ -6,13 +6,14 @@ from openpyxl.styles import PatternFill
 from copy import copy as copy_style
 
 from utils.logger import Logger
+from utils.markdown_logger import MarkdownLogger
 
 class ExcelProcessor:
     def __init__(
         self, main_excel_path, folder_path, copy_column, selected_sheets,
         sheet_to_header_row, sheet_to_column, file_to_column=None, folder_to_column=None,
         file_to_sheet_map=None, skip_first_row=False, copy_by_row_number=False,
-        preserve_formatting=False, logger=None
+        preserve_formatting=False, logger=None, markdown_logger=None
     ):
         self.main_excel_path = main_excel_path
         self.folder_path = folder_path
@@ -32,6 +33,7 @@ class ExcelProcessor:
         self.header_row = {}
 
         self.logger = logger or Logger()
+        self.markdown_logger = markdown_logger or MarkdownLogger()
 
     @staticmethod
     def get_sheet_names(excel_path):
@@ -116,6 +118,8 @@ class ExcelProcessor:
         self.workbook.save(output_file)
         self.logger.log_info(f"Файл успешно сохранён: {output_file}")
         self.logger.save()
+        if self.markdown_logger:
+            self.markdown_logger.save()
         self.workbook.close()
         return output_file
 
@@ -237,6 +241,16 @@ class ExcelProcessor:
                     target_cell_ref,
                     value,
                 )
+                if self.markdown_logger:
+                    self.markdown_logger.log_copy(
+                        source_path or "",
+                        source_sheet or "",
+                        source_cell_ref,
+                        self.main_excel_path,
+                        sheet_name,
+                        target_cell_ref,
+                        value,
+                    )
                 break
         else:
             fill = PatternFill(start_color="FF0000", end_color="FF0000", fill_type="solid")

--- a/utils/markdown_logger.py
+++ b/utils/markdown_logger.py
@@ -1,0 +1,85 @@
+"""Markdown logger for detailed copy sessions.
+
+This module collects detailed information about copy operations
+and saves them into a Markdown file with rich formatting so that
+users can easily trace where each value came from and where it was
+placed.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+from typing import Any, Dict, List
+
+
+class MarkdownLogger:
+    """Collects copy operations and renders them into Markdown."""
+
+    def __init__(self, markdown_file: str = "copy_report.md") -> None:
+        self.markdown_file = markdown_file
+        self.entries: List[Dict[str, Any]] = []
+        self.session_started = datetime.datetime.now()
+
+    def log_copy(
+        self,
+        source_file: str,
+        source_sheet: str,
+        source_cell: str,
+        target_file: str,
+        target_sheet: str,
+        target_cell: str,
+        value: Any,
+    ) -> None:
+        """Store a copy event for later Markdown rendering."""
+
+        self.entries.append(
+            {
+                "source_file": source_file or "—",
+                "source_sheet": source_sheet or "—",
+                "source_cell": source_cell or "—",
+                "target_file": target_file or "—",
+                "target_sheet": target_sheet or "—",
+                "target_cell": target_cell or "—",
+                "value": self._format_value(value),
+            }
+        )
+
+    def save(self) -> None:
+        if not self.entries:
+            return
+
+        os.makedirs(os.path.dirname(self.markdown_file) or ".", exist_ok=True)
+
+        session_title = self.session_started.strftime("%Y-%m-%d %H:%M:%S")
+        with open(self.markdown_file, "a", encoding="utf-8") as md_file:
+            md_file.write(f"## Сессия копирования от {session_title}\n\n")
+            md_file.write("| Источник | Приёмник | Текст |\n")
+            md_file.write("| --- | --- | --- |\n")
+            for entry in self.entries:
+                source = self._format_endpoint(entry, "source")
+                target = self._format_endpoint(entry, "target")
+                text_block = self._format_text_block(entry["value"])
+                md_file.write(f"| {source} | {target} | {text_block} |\n")
+            md_file.write("\n")
+
+        self.entries.clear()
+        self.session_started = datetime.datetime.now()
+
+    def _format_value(self, value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).replace("\r\n", "\n")
+
+    def _format_endpoint(self, entry: Dict[str, Any], prefix: str) -> str:
+        file_key = f"{prefix}_file"
+        sheet_key = f"{prefix}_sheet"
+        cell_key = f"{prefix}_cell"
+        file_path = entry.get(file_key, "—")
+        sheet = entry.get(sheet_key, "—")
+        cell = entry.get(cell_key, "—")
+        return f"`{file_path}`<br>`{sheet}!{cell}`"
+
+    def _format_text_block(self, text: str) -> str:
+        safe_text = (text or "").replace("|", "\\|")
+        return f"```\n{safe_text}\n```"


### PR DESCRIPTION
## Summary
- add a MarkdownLogger module to capture detailed copy operations in rich Markdown format
- integrate the ExcelProcessor to record copy operations and persist the Markdown report after copying

## Testing
- python -m compileall utils core

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928bc4e96bc832c9f2ad6e73aa5db72)