### PR TITLE
Handle non-string RGB values during split

### DIFF
--- a/core/split_excel.py
+++ b/core/split_excel.py
@@ -21,6 +21,16 @@ def _normalize_color(color) -> str | None:
     rgb = getattr(color, "rgb", None)
     if not rgb:
         return None
+    if isinstance(rgb, bytes):
+        rgb = rgb.decode()
+    # Some color objects expose an RGB helper instead of a plain string
+    if not isinstance(rgb, str):
+        nested_rgb = getattr(rgb, "rgb", None) or getattr(rgb, "value", None)
+        if isinstance(nested_rgb, bytes):
+            nested_rgb = nested_rgb.decode()
+        rgb = nested_rgb if isinstance(nested_rgb, str) else None
+    if not rgb:
+        return None
     if len(rgb) == 8:
         return rgb[-6:]
     if len(rgb) == 6:

--- a/tests/test_split_excel.py
+++ b/tests/test_split_excel.py
@@ -1,6 +1,10 @@
 import os
 from openpyxl import Workbook, load_workbook
-from core.split_excel import split_excel_by_languages, split_excel_multiple_sheets
+from core.split_excel import (
+    split_excel_by_languages,
+    split_excel_multiple_sheets,
+    _normalize_color,
+)
 
 
 def test_split_excel_without_header(tmp_path):
@@ -24,6 +28,17 @@ def test_split_excel_without_header(tmp_path):
     assert ws_out.cell(row=2, column=1).value == "привет"
     assert ws_out.cell(row=2, column=2).value == "hallo"
     wb_out.close()
+
+
+def test_normalize_color_with_non_string_rgb():
+    class DummyRGB:
+        pass
+
+    class DummyColor:
+        def __init__(self):
+            self.rgb = DummyRGB()
+
+    assert _normalize_color(DummyColor()) is None
 
 def test_split_excel(tmp_path):
     src = tmp_path / "main.xlsx"


### PR DESCRIPTION
## Summary
- avoid crashing when normalizing colors that provide non-string RGB values
- add a regression test for color normalization with non-string RGB objects

## Testing
- ⚠️ `PYTHONPATH=. pytest tests/test_split_excel.py` *(fails: missing XlsxWriter dependency; installation blocked by proxy restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a0706f85c832ca980e1acd5b07aac)