### PR TITLE
Process sheet renames last and adjust builder UI layout

### DIFF
--- a/excel_builder/executor.py
+++ b/excel_builder/executor.py
@@ -57,8 +57,6 @@ class ExcelBuilderExecutor:
             return
 
         rename_ops = [op for op in operations if op["type"] == "rename_sheet" and self._op_matches(op, file_info["path"])]
-        if rename_ops:
-            self._rename_sheets_openpyxl(workbook, rename_ops)
 
         for op in operations:
             if op["type"] == "rename_sheet":
@@ -79,6 +77,9 @@ class ExcelBuilderExecutor:
             elif op["type"] == "clear_column":
                 self._clear_column_openpyxl(sheet, op)
 
+        if rename_ops:
+            self._rename_sheets_openpyxl(workbook, rename_ops)
+
         rel_path = file_info["rel"]
         dest_path = os.path.join(output_root, rel_path)
         os.makedirs(os.path.dirname(dest_path), exist_ok=True)
@@ -89,8 +90,6 @@ class ExcelBuilderExecutor:
     # region operation handling
     def _apply_operations(self, sheets: Dict[str, pd.DataFrame], operations: List[Dict], file_path: str):
         rename_ops = [op for op in operations if op["type"] == "rename_sheet" and self._op_matches(op, file_path)]
-        if rename_ops:
-            sheets = self._rename_sheets(sheets, rename_ops)
 
         for op in operations:
             if op["type"] == "rename_sheet":
@@ -111,6 +110,9 @@ class ExcelBuilderExecutor:
             elif op["type"] == "clear_column":
                 df = self._clear_column(df, op)
             sheets[sheet_name] = df
+
+        if rename_ops:
+            sheets = self._rename_sheets(sheets, rename_ops)
         return sheets
 
     def _rename_sheets(self, sheets: Dict[str, pd.DataFrame], operations: List[Dict]):


### PR DESCRIPTION
## Summary
- run sheet rename operations after other actions so other operations use the original sheet names
- limit the loaded files list, operations list, and log display to fixed row counts with scrollbars
- show a clickable link to the output folder when executing builder actions

## Testing
- python -m pytest *(fails: ImportError: libGL.so.1 missing in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a1bc7897c832c8ff437bd3b83f914)