### PR TITLE
Use gear icon tab and show full Excel names

### DIFF
--- a/gui/excel_builder_tab.py
+++ b/gui/excel_builder_tab.py
@@ -301,12 +301,17 @@ class ExcelBuilderTab(QWidget):
         self.scope_combo.addItem(tr("Все файлы"), userData="all")
         for f in self.manager.files:
             name = self._display_name(f["path"])
-            item = QListWidgetItem(self._short_name(name))
+            item = QListWidgetItem(name)
             item.setToolTip(f["path"])
             self.file_list.addItem(item)
 
-            self.preview_file_combo.addItem(self._short_name(name), userData=f)
-            self.scope_combo.addItem(self._short_name(name), userData=f["path"])
+            self.preview_file_combo.addItem(name, userData=f)
+            index = self.preview_file_combo.count() - 1
+            self.preview_file_combo.setItemData(index, name, role=Qt.ToolTipRole)
+
+            self.scope_combo.addItem(name, userData=f["path"])
+            scope_index = self.scope_combo.count() - 1
+            self.scope_combo.setItemData(scope_index, name, role=Qt.ToolTipRole)
         self.preview_file_combo.blockSignals(False)
         self.scope_combo.blockSignals(False)
         self._on_preview_file_changed()
@@ -466,7 +471,7 @@ class ExcelBuilderTab(QWidget):
         self._update_list_rows(self.operations_list, self.operations_list.count(), max_rows=5)
 
     def _describe_operation(self, op: Dict) -> str:
-        scope = tr("все") if op.get("scope") == "all" else self._short_name(self._display_name(op.get("scope", "")))
+        scope = tr("все") if op.get("scope") == "all" else self._display_name(op.get("scope", ""))
         if op["type"] == "rename_header":
             return f"[{scope}] {op['sheet']}: {op['identifier']} -> {op['new']}"
         if op["type"] == "fill_cell":
@@ -518,12 +523,7 @@ class ExcelBuilderTab(QWidget):
         QMessageBox.information(self, tr("Готово"), tr("Обработка завершена"))
 
     def _display_name(self, path: str) -> str:
-        base = os.path.basename(path)
-        name, _ = os.path.splitext(base)
-        return name
-
-    def _short_name(self, path: str, n: int = 5) -> str:
-        return path if len(path) <= 2 * n else f"{path[:n]}...{path[-n:]}"
+        return os.path.basename(path)
 
     def _log_line(self, text: str):
         logger.info(text)

--- a/gui/excel_file_selector.py
+++ b/gui/excel_file_selector.py
@@ -54,8 +54,10 @@ class ExcelFileSelector(QDialog):
 
     def add_file_to_list(self, file_path):
         """Добавление файла в QListWidget."""
-        item = QListWidgetItem(os.path.splitext(os.path.basename(file_path))[0])
+        file_name = os.path.basename(file_path)
+        item = QListWidgetItem(file_name)
         item.setData(Qt.UserRole, file_path)
+        item.setToolTip(file_name)
         self.file_list.addItem(item)
 
     def show_warning_no_files(self):

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import QMainWindow, QMessageBox, QTabWidget
-from PySide6.QtGui import QAction, QIcon, QFont
+from PySide6.QtGui import QAction, QIcon, QFont, QPixmap, QPainter
 from PySide6.QtCore import Qt
 from utils.i18n import tr, i18n
 from __init__ import __version__
@@ -38,7 +38,10 @@ class MainWindow(QMainWindow):
         self.tab_widget.addTab(self.merge_tab_widget, tr("Объединить"))
 
         self.excel_builder_widget = ExcelBuilderTab()
-        self.tab_widget.addTab(self.excel_builder_widget, tr("Конструктор Excel"))
+        settings_icon = self._get_settings_icon()
+        self.tab_widget.addTab(self.excel_builder_widget, "")
+        self.tab_widget.setTabIcon(4, settings_icon)
+        self.tab_widget.setTabToolTip(4, tr("Конструктор Excel"))
 
         self.setCentralWidget(self.tab_widget)
         self.apply_modern_style()
@@ -145,7 +148,9 @@ class MainWindow(QMainWindow):
         self.tab_widget.setTabText(1, tr("Лимит чек"))
         self.tab_widget.setTabText(2, tr("xlSpliter"))
         self.tab_widget.setTabText(3, tr("Объединить"))
-        self.tab_widget.setTabText(4, tr("Конструктор Excel"))
+        self.tab_widget.setTabText(4, "")
+        self.tab_widget.setTabIcon(4, self._get_settings_icon())
+        self.tab_widget.setTabToolTip(4, tr("Конструктор Excel"))
 
     def init_menu(self):
         menubar = self.menuBar()
@@ -178,6 +183,24 @@ class MainWindow(QMainWindow):
         self.about_action = about_action
         i18n.language_changed.connect(self.retranslate_ui)
         self.retranslate_ui()
+
+    def _get_settings_icon(self) -> QIcon:
+        icon = QIcon.fromTheme("settings")
+        if not icon.isNull():
+            return icon
+
+        pixmap = QPixmap(32, 32)
+        pixmap.fill(Qt.transparent)
+
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.Antialiasing)
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(Qt.black)
+        painter.setFont(QFont(self.font().family(), 20))
+        painter.drawText(pixmap.rect(), Qt.AlignCenter, "⚙")
+        painter.end()
+
+        return QIcon(pixmap)
 
     def show_about(self):
         info_text = (


### PR DESCRIPTION
## Summary
- replace the Excel builder tab label with a gear icon and tooltip
- show full Excel filenames in selectors and combos while adding tooltips for hover hints

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a245de108832cb73c488f6eb9574d)