### PR TITLE
Adjust builder menu placement and preview height

### DIFF
--- a/gui/excel_builder_tab.py
+++ b/gui/excel_builder_tab.py
@@ -147,7 +147,7 @@ class ExcelBuilderTab(QWidget):
         self.preview_table = QTableWidget()
         self.preview_table.setRowCount(0)
         self.preview_table.setColumnCount(0)
-        self.preview_table.setMinimumHeight(320)
+        self.preview_table.setMinimumHeight(120)
         self.preview_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         vbox.addWidget(self.preview_table)
         self._update_preview_height(self.preview_height_slider.value())

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -49,7 +49,6 @@ class MainWindow(QMainWindow):
         self.main_screen = QWidget()
         main_layout = QVBoxLayout(self.main_screen)
         main_layout.setContentsMargins(0, 0, 0, 0)
-        main_layout.addLayout(self._create_main_header())
         main_layout.addWidget(self.tab_widget)
 
         self.excel_builder_widget = ExcelBuilderTab()
@@ -164,12 +163,8 @@ class MainWindow(QMainWindow):
         self.tab_widget.setTabText(1, tr("Лимит чек"))
         self.tab_widget.setTabText(2, tr("xlSpliter"))
         self.tab_widget.setTabText(3, tr("Объединить"))
-        self.builder_action.setText(self._get_builder_tab_text())
         self.builder_action.setIcon(self._get_settings_icon())
         self.builder_action.setToolTip(tr("Конструктор Excel"))
-        self.builder_menu_button.setText(self._get_builder_tab_text())
-        self.builder_menu_button.setIcon(self._get_settings_icon())
-        self.builder_menu_button.setToolTip(tr("Конструктор Excel"))
         self.back_button.setText(self._get_back_button_text())
 
     def init_menu(self):
@@ -200,28 +195,13 @@ class MainWindow(QMainWindow):
         self.lang_en_action = lang_en
         self.lang_ru_action = lang_ru
 
-        self.builder_action = QAction(self._get_settings_icon(), self._get_builder_tab_text(), self)
+        self.builder_action = QAction(self._get_settings_icon(), "", self)
         self.builder_action.triggered.connect(self.show_builder_page)
         menubar.addAction(self.builder_action)
 
         self.about_action = about_action
         i18n.language_changed.connect(self.retranslate_ui)
         self.retranslate_ui()
-
-    def _create_main_header(self) -> QHBoxLayout:
-        header = QHBoxLayout()
-        header.setContentsMargins(8, 8, 8, 8)
-
-        header.addStretch()
-
-        self.builder_menu_button = QPushButton(self._get_builder_tab_text())
-        self.builder_menu_button.setIcon(self._get_settings_icon())
-        self.builder_menu_button.setFlat(True)
-        self.builder_menu_button.setCursor(Qt.PointingHandCursor)
-        self.builder_menu_button.clicked.connect(self.show_builder_page)
-        header.addWidget(self.builder_menu_button)
-
-        return header
 
     def _create_builder_page(self) -> QWidget:
         page = QWidget()
@@ -262,11 +242,8 @@ class MainWindow(QMainWindow):
 
         return QIcon(pixmap)
 
-    def _get_builder_tab_text(self) -> str:
-        return f"⚙ {tr('Конструктор Excel')}"
-
     def _get_back_button_text(self) -> str:
-        return f"← {tr('Назад')}"
+        return "←"
 
     def show_about(self):
         info_text = (


### PR DESCRIPTION
## Summary
- move the Excel builder entry to an icon-only gear action in the menu bar after the language menu and drop the old header button
- simplify the builder page back control to display only the back arrow
- lower the preview table minimum height to 120px to allow compact previews

## Testing
- not run (GUI changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a2963dbe8832c98f2e7ca1ca91639)