### PR TITLE
Fix settings menu visibility and adjust preview height default

### DIFF
--- a/gui/excel_builder_tab.py
+++ b/gui/excel_builder_tab.py
@@ -129,11 +129,11 @@ class ExcelBuilderTab(QWidget):
         preview_controls.addWidget(QLabel(tr("Высота превью")))
         self.preview_height_slider = QSlider(Qt.Horizontal)
         self.preview_height_slider.setRange(120, 800)
-        self.preview_height_slider.setValue(320)
+        self.preview_height_slider.setValue(120)
         self.preview_height_slider.setSingleStep(10)
         self.preview_height_slider.valueChanged.connect(self._update_preview_height)
         preview_controls.addWidget(self.preview_height_slider, 1)
-        self.preview_height_label = QLabel("320 px")
+        self.preview_height_label = QLabel("120 px")
         preview_controls.addWidget(self.preview_height_label)
 
         self.preview_toggle = QToolButton()

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -195,7 +195,7 @@ class MainWindow(QMainWindow):
         self.lang_en_action = lang_en
         self.lang_ru_action = lang_ru
 
-        self.builder_action = QAction(self._get_settings_icon(), "", self)
+        self.builder_action = QAction(self._get_settings_icon(), "⚙", self)
         self.builder_action.triggered.connect(self.show_builder_page)
         menubar.addAction(self.builder_action)
 


### PR DESCRIPTION
## Summary
- ensure the settings action in the menu bar remains visible by giving it a gear label
- set the Excel builder preview height slider default to 120 px for smaller previews

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a2a759914832cb61e353742c9ecfe)