### PR TITLE
Fix window icon handling

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -29,7 +29,7 @@ class MainWindow(QMainWindow):
 
     def setup_ui(self):
         self.setWindowTitle(tr("xlMerger: объединяй и проверяй"))
-        self.setWindowIcon(QIcon(r"C:\\Users\\yanismik\\Desktop\\PythonProject1\\xlM_2.0\\xlM2.0.ico"))
+        self.setWindowIcon(self._get_app_icon())
         self.setMinimumSize(650, 450)
 
         self.tab_widget = QTabWidget()
@@ -238,6 +238,24 @@ class MainWindow(QMainWindow):
         painter.setBrush(Qt.black)
         painter.setFont(QFont(self.font().family(), 20))
         painter.drawText(pixmap.rect(), Qt.AlignCenter, "⚙")
+        painter.end()
+
+        return QIcon(pixmap)
+
+    def _get_app_icon(self) -> QIcon:
+        icon = QIcon.fromTheme("spreadsheet")
+        if not icon.isNull():
+            return icon
+
+        pixmap = QPixmap(64, 64)
+        pixmap.fill(Qt.transparent)
+
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.Antialiasing)
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(Qt.black)
+        painter.setFont(QFont(self.font().family(), 28, QFont.Bold))
+        painter.drawText(pixmap.rect(), Qt.AlignCenter, "XL")
         painter.end()
 
         return QIcon(pixmap)


### PR DESCRIPTION
## Summary
- set the main window icon using a theme icon with a drawn fallback
- remove hardcoded local icon path so the application icon always renders

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a2b3a4144832c99bc836679aa69ac)