### PR TITLE
Add multi-target merge support in GUI

### DIFF
--- a/gui/merge_tab.py
+++ b/gui/merge_tab.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 import os
 import subprocess
 import platform
@@ -9,11 +9,16 @@ from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QMessageBox, QLabel, QGroupBox, QProgressBar
 )
 
-from PySide6.QtCore import QTimer, Qt, QThread, Signal
+from PySide6.QtCore import Qt, QThread, Signal
 
 from utils.i18n import tr, i18n
 from core.drag_drop import DragDropLineEdit
 from core.merge_columns import merge_excel_columns
+from core.multi_target_merge import (
+    TargetMergePlan,
+    merge_translations_to_many_targets,
+    suggest_target_mapping,
+)
 from .merge_mapping_dialog import MergeMappingDialog
 
 
@@ -51,12 +56,46 @@ class MergeWorker(QThread):
             self.error.emit(str(e))
 
 
+class MultiTargetMergeWorker(QThread):
+    finished = Signal(list)
+    error = Signal(str)
+    progress = Signal(int, str)
+
+    def __init__(self, plans: List[TargetMergePlan], sources: List[str], manual_mapping: Dict[str, str] | None = None):
+        super().__init__()
+        self.plans = plans
+        self.sources = sources
+        self.manual_mapping = manual_mapping or {}
+        self.outputs: List[str] = []
+
+    def run(self):
+        try:
+            self.progress.emit(1, tr("Подготовка файлов..."))
+
+            def progress_callback(percent: int, message: str):
+                self.progress.emit(percent, message)
+
+            self.outputs = merge_translations_to_many_targets(
+                self.plans,
+                self.sources,
+                manual_mapping=self.manual_mapping,
+                progress_callback=progress_callback,
+            )
+
+            self.progress.emit(100, tr("Объединение завершено!"))
+            self.finished.emit(self.outputs)
+        except Exception as e:
+            self.error.emit(str(e))
+
+
 class MergeTab(QWidget):
     def __init__(self):
         super().__init__()
         self.source_files: List[str] = []
-        self.main_file = ""
-        self.mappings = []
+        self.main_files: List[str] = []
+        self.mappings: List[dict] = []
+        self.plans: List[TargetMergePlan] = []
+        self.manual_mapping: Dict[str, str] = {}
         self.is_processing = False
         self.worker = None
         self.init_ui()
@@ -71,8 +110,9 @@ class MergeTab(QWidget):
         main_group = QGroupBox()
         main_layout = QVBoxLayout()
         self.main_label = QLabel()
-        self.main_file_input = DragDropLineEdit(mode='file')
-        self.main_file_input.fileSelected.connect(self.handle_main_file_selected)
+        self.main_file_input = DragDropLineEdit(mode='files_or_folder')
+        self.main_file_input.filesSelected.connect(self.handle_main_files_selected)
+        self.main_file_input.folderSelected.connect(self.handle_main_folder_selected)
         main_layout.addWidget(self.main_label)
         main_layout.addWidget(self.main_file_input)
         main_group.setLayout(main_layout)
@@ -149,10 +189,38 @@ class MergeTab(QWidget):
         layout.addStretch()
 
     def handle_main_file_selected(self, file_path: str):
-        self.main_file = file_path
+        # Поддержка обратной совместимости, если signal fileSelected сработает
+        self.main_files = [file_path]
+
+    def handle_main_files_selected(self, files: List[str]):
+        self.main_files = list(files)
+        self._reset_config()
+        if len(self.main_files) == 1:
+            self.main_file_input.setText(os.path.basename(self.main_files[0]))
+        else:
+            short_names = [os.path.basename(f) for f in self.main_files]
+            self.main_file_input.setText(
+                tr("{count} файлов выбрано").format(count=len(short_names))
+            )
+
+    def handle_main_folder_selected(self, folder: str):
+        excel_exts = ('.xlsx', '.xls')
+        if os.path.isdir(folder):
+            self.main_files = [
+                os.path.join(folder, f)
+                for f in os.listdir(folder)
+                if f.lower().endswith(excel_exts)
+            ]
+            self._reset_config()
+            self.main_file_input.setText(
+                tr("Найдено файлов: {count}").format(count=len(self.main_files))
+            )
+        else:
+            self.main_files = []
 
     def handle_files_selected(self, files: List[str]):
         self.source_files = files
+        self._reset_config()
 
     def handle_folder_selected(self, folder: str):
         excel_exts = ('.xlsx', '.xls')
@@ -164,34 +232,61 @@ class MergeTab(QWidget):
             ]
         else:
             self.source_files = []
+        self._reset_config()
 
     def open_preview(self):
-        if not self.main_file:
-            QMessageBox.critical(self, tr("Ошибка"), tr("Укажи основной Excel."))
+        if not self.main_files:
+            QMessageBox.critical(self, tr("Ошибка"), tr("Укажи основной(ые) Excel."))
             return
         if not self.source_files:
             QMessageBox.critical(self, tr("Ошибка"), tr("Укажи файлы источников."))
             return
 
-        dialog = MergeMappingDialog(self.main_file, self)
-        for f in self.source_files:
-            dialog.add_row_with_file(f)
-        if dialog.exec():
-            self.mappings = dialog.get_mappings()
-            self.merge_btn.setEnabled(True)
-            self.status_label.setText(tr("Настройки сохранены. Готово к объединению."))
+        if len(self.main_files) == 1:
+            dialog = MergeMappingDialog(self.main_files[0], self)
+            for f in self.source_files:
+                dialog.add_row_with_file(f)
+            if dialog.exec():
+                self.mappings = dialog.get_mappings()
+                self.merge_btn.setEnabled(True)
+                self.status_label.setText(tr("Настройки сохранены. Готово к объединению."))
+                self.plans = [TargetMergePlan(main_file=self.main_files[0], mappings=self.mappings)]
+                self.manual_mapping = self._build_manual_mapping(self.plans)
+        else:
+            assignments = suggest_target_mapping(self.source_files, self.main_files)
+            plans: List[TargetMergePlan] = []
+            for main_file in self.main_files:
+                dialog = MergeMappingDialog(main_file, self)
+                for f in assignments.get(main_file, self.source_files):
+                    dialog.add_row_with_file(f)
+                if not dialog.exec():
+                    return
+                mappings = dialog.get_mappings()
+                if mappings:
+                    plans.append(TargetMergePlan(main_file=main_file, mappings=mappings))
+            if plans:
+                self.plans = plans
+                self.manual_mapping = self._build_manual_mapping(plans)
+                self.merge_btn.setEnabled(True)
+                self.status_label.setText(tr("Настройки сохранены для нескольких целей."))
 
     def run_merge(self):
-        if not self.main_file:
-            QMessageBox.critical(self, tr("Ошибка"), tr("Укажи основной Excel."))
+        if not self.main_files:
+            QMessageBox.critical(self, tr("Ошибка"), tr("Укажи основной(ые) Excel."))
             return
         if not self.source_files:
             QMessageBox.critical(self, tr("Ошибка"), tr("Укажи файлы источников."))
             return
-        if not self.mappings:
-            QMessageBox.warning(self, tr("Предупреждение"),
-                                tr("Сначала настройте сопоставления через кнопку Настроить."))
-            return
+        if len(self.main_files) == 1:
+            if not self.mappings:
+                QMessageBox.warning(self, tr("Предупреждение"),
+                                    tr("Сначала настройте сопоставления через кнопку Настроить."))
+                return
+        else:
+            if not self.plans:
+                QMessageBox.warning(self, tr("Предупреждение"),
+                                    tr("Сначала настройте сопоставления через кнопку Настроить."))
+                return
 
         if self.is_processing:
             return
@@ -206,10 +301,16 @@ class MergeTab(QWidget):
         self.progress_bar.setValue(0)
         self.status_label.setText(tr("Начинаем объединение..."))
 
-        self.worker = MergeWorker(self.main_file, self.mappings)
-        self.worker.finished.connect(self.on_merge_finished)
-        self.worker.error.connect(self.on_merge_error)
-        self.worker.progress.connect(self.on_progress_update)
+        if len(self.main_files) == 1:
+            self.worker = MergeWorker(self.main_files[0], self.mappings)
+            self.worker.finished.connect(self.on_merge_finished)
+            self.worker.error.connect(self.on_merge_error)
+            self.worker.progress.connect(self.on_progress_update)
+        else:
+            self.worker = MultiTargetMergeWorker(self.plans, self.source_files, manual_mapping=self.manual_mapping)
+            self.worker.finished.connect(self.on_multi_merge_finished)
+            self.worker.error.connect(self.on_merge_error)
+            self.worker.progress.connect(self.on_progress_update)
         self.worker.start()
 
     def on_progress_update(self, value, message):
@@ -231,6 +332,23 @@ class MergeTab(QWidget):
         self.merge_btn.setEnabled(True)
         self.configure_btn.setEnabled(True)
 
+    def on_multi_merge_finished(self, output_files: List[str]):
+        self.worker = None
+        self.output_files = output_files
+        self.progress_bar.setValue(100)
+        self.status_label.setText(tr("Объединение завершено успешно!"))
+        self.status_label.setStyleSheet("color: #28a745; font-weight: bold;")
+
+        links = "<br>".join(
+            f'<a href="file:///{path}">{os.path.basename(path)}</a>' for path in output_files
+        )
+        self.file_link.setText(links)
+        self.file_link.setVisible(True)
+
+        self.is_processing = False
+        self.merge_btn.setEnabled(True)
+        self.configure_btn.setEnabled(True)
+
     def on_merge_error(self, error_message):
         self.worker = None
         self.progress_bar.setVisible(False)
@@ -245,18 +363,40 @@ class MergeTab(QWidget):
         QMessageBox.critical(self, tr("Ошибка"), error_message)
 
     def open_file_location(self, link):
-        if hasattr(self, 'output_file'):
-            folder = os.path.dirname(self.output_file)
+        target_path = link
+        if not target_path and hasattr(self, 'output_file'):
+            target_path = self.output_file
+
+        if target_path:
+            folder = os.path.dirname(target_path)
             if platform.system() == 'Windows':
-                subprocess.run(['explorer', '/select,', os.path.normpath(self.output_file)])
+                subprocess.run(['explorer', '/select,', os.path.normpath(target_path)])
             elif platform.system() == 'Darwin':
-                subprocess.run(['open', '-R', self.output_file])
+                subprocess.run(['open', '-R', target_path])
             else:
                 subprocess.run(['xdg-open', folder])
 
+    def _build_manual_mapping(self, plans: List[TargetMergePlan]) -> Dict[str, str]:
+        mapping: Dict[str, str] = {}
+        for plan in plans:
+            for m in plan.mappings:
+                src = m.get("source")
+                if src:
+                    mapping[src] = plan.main_file
+        return mapping
+
+    def _reset_config(self):
+        self.mappings = []
+        self.plans = []
+        self.manual_mapping = {}
+        self.merge_btn.setEnabled(False)
+        if hasattr(self, "status_label"):
+            self.status_label.setText(tr("Сначала настройте сопоставления"))
+        self.file_link.setVisible(False)
+
     def retranslate_ui(self):
-        self.main_label.setText(tr("Основной Excel файл:"))
-        self.main_file_input.setPlaceholderText(tr("Перетащи или кликни дважды"))
+        self.main_label.setText(tr("Основной Excel файл(ы):"))
+        self.main_file_input.setPlaceholderText(tr("Перетащи или кликни дважды (можно несколько)"))
         self.sources_label.setText(tr("Файлы источников:"))
         self.sources_input.setPlaceholderText(tr("Перетащи или кликни дважды"))
         self.configure_btn.setText(tr("Настроить"))
@@ -264,3 +404,4 @@ class MergeTab(QWidget):
 
         if hasattr(self, 'status_label') and not self.mappings:
             self.status_label.setText(tr("Сначала настройте сопоставления"))
+


### PR DESCRIPTION
## Summary
- integrate multi-target merge workflow into the GUI merge tab with a dedicated worker
- allow selecting multiple target Excel files or folders and configure mappings per target
- show multiple output links after merging and reset mappings when inputs change

## Testing
- pytest tests/test_multi_target_merge.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2a7209e0832cb71408951a71f748)