### PR TITLE
Allow multiple target Excel files

### DIFF
--- a/core/drag_drop.py
+++ b/core/drag_drop.py
@@ -11,7 +11,7 @@ class DragDropLineEdit(QLineEdit):
         super().__init__(parent)
         self.setAcceptDrops(True)
         self.setReadOnly(True)
-        self.mode = mode  # 'files_or_folder' или 'file'
+        self.mode = mode  # 'files_or_folder', 'file' или 'files_only'
         self.setStyleSheet(
             """
             QLineEdit {
@@ -44,6 +44,14 @@ class DragDropLineEdit(QLineEdit):
             else:
                 self.clear()
 
+        # Для поля "Файл(ы) Excel" — только эксели, можно несколько
+        elif self.mode == 'files_only':
+            if files and not folders:
+                self.setText('; '.join([self._short_name(f) for f in files]))
+                self.filesSelected.emit(files)
+            else:
+                self.clear()
+
         # Для поля "Папка переводов" — либо папка, либо только эксели
         elif self.mode == 'files_or_folder':
             if files and not folders:
@@ -70,6 +78,15 @@ class DragDropLineEdit(QLineEdit):
                 if folder:
                     self.setText(folder)
                     self.folderSelected.emit(folder)
+        elif self.mode == 'files_only':
+            dlg = QFileDialog(self)
+            dlg.setFileMode(QFileDialog.ExistingFiles)
+            dlg.setNameFilter("Excel файлы (*.xlsx *.xls)")
+            if dlg.exec():
+                files = dlg.selectedFiles()
+                if files:
+                    self.setText('; '.join([self._short_name(f) for f in files]))
+                    self.filesSelected.emit(files)
         elif self.mode == 'file':
             file, _ = QFileDialog.getOpenFileName(self, "Выбери файл", '', "Excel файлы (*.xlsx *.xls)")
             if file:

--- a/gui/main_page.py
+++ b/gui/main_page.py
@@ -14,6 +14,7 @@ class MainPageWidget(QWidget):
     folderSelected = Signal(str)
     filesSelected = Signal(list)
     excelFileSelected = Signal(str)
+    excelFilesSelected = Signal(list)
     processTriggered = Signal()
     previewTriggered = Signal()
 
@@ -53,9 +54,10 @@ class MainPageWidget(QWidget):
 
     def create_excel_selection_layout(self):
         layout = QHBoxLayout()
-        self.excel_file_entry = DragDropLineEdit(mode='file')
-        self.excel_file_entry.setPlaceholderText(tr("Перетащи или кликни дважды"))
+        self.excel_file_entry = DragDropLineEdit(mode='files_only')
+        self.excel_file_entry.setPlaceholderText(tr("Перетащи или кликни дважды (можно несколько)"))
         self.excel_file_entry.fileSelected.connect(self.excelFileSelected)
+        self.excel_file_entry.filesSelected.connect(self.excelFilesSelected)
         self.excel_label = QLabel()
         layout.addWidget(self.excel_label)
         layout.addWidget(self.excel_file_entry)
@@ -142,9 +144,9 @@ class MainPageWidget(QWidget):
 
     def retranslate_ui(self):
         self.folder_entry.setPlaceholderText(tr("Перетащи или кликни дважды"))
-        self.excel_file_entry.setPlaceholderText(tr("Перетащи или кликни дважды"))
+        self.excel_file_entry.setPlaceholderText(tr("Перетащи или кликни дважды (можно несколько)"))
         self.folder_label.setText(tr("Папка/эксели с переводами:"))
-        self.excel_label.setText(tr("Целевой Excel:"))
+        self.excel_label.setText(tr("Целевые Excel файлы:"))
         self.copy_column_label.setText(tr("Из какой колонки копировать? (буква колонки):"))
         self.skip_first_row_checkbox.setText(tr("Первая строка — заголовок в переводах"))
         self.copy_by_matching_radio.setText(tr("Нет пустых/скрытых строк в xlsx"))


### PR DESCRIPTION
## Summary
- allow selecting multiple target Excel files in the xlMerger tab
- validate sheet compatibility and process each target sequentially with progress updates
- expand drag-and-drop control to support multi-file Excel selection

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5e07c100832c9be4833b82e93cc1)