### PR TITLE
Allow multiple drag-and-drop target Excel selections

### DIFF
--- a/gui/merge_tab.py
+++ b/gui/merge_tab.py
@@ -156,7 +156,12 @@ class MergeTab(QWidget):
         layout.addStretch()
 
     def handle_target_files_selected(self, files: List[str]):
-        self.target_files = files
+        combined = []
+        for path in [*self.target_files, *files]:
+            if path not in combined:
+                combined.append(path)
+        self.target_files = combined
+        self.target_files_input.setText('; '.join([self.target_files_input._short_name(f) for f in combined]))
 
     def handle_files_selected(self, files: List[str]):
         self.source_files = files


### PR DESCRIPTION
## Summary
- keep previously selected target Excel files when new ones are dropped
- update drag-and-drop field text to reflect the combined target list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f64671480832cb7d085eb6d515064)