### PR TITLE
Fix translation copy for file-based inputs (preserve paths & flexible sheet mapping)

### DIFF
--- a/core/excel_processor.py
+++ b/core/excel_processor.py
@@ -96,7 +96,9 @@ class ExcelProcessor:
 
                 col_index = self.columns[sheet_name].index(column_name) + 1
                 if is_file_mapping:
-                    file_path = os.path.join(self.folder_path, name)
+                    file_path = name
+                    if not os.path.isabs(file_path) and self.folder_path:
+                        file_path = os.path.join(self.folder_path, name)
                     self.logger.log_info(f"Копирование из файла: {file_path}, лист: {sheet_name}, столбец: {column_name}")
                     self._copy_from_file(
                         file_path, sheet_name, copy_col_index, header_row, col_index
@@ -121,7 +123,12 @@ class ExcelProcessor:
 
     def _find_matching_sheet(self, lang_wb, main_sheet_name, file_path=None):
         if file_path:
-            mapping = self.file_to_sheet_map.get(file_path, {}).get(main_sheet_name)
+            lookup_keys = [file_path, os.path.abspath(file_path), os.path.basename(file_path)]
+            mapping = None
+            for key in lookup_keys:
+                mapping = self.file_to_sheet_map.get(key, {}).get(main_sheet_name)
+                if mapping:
+                    break
             if mapping and mapping in lang_wb.sheetnames:
                 return mapping
         if main_sheet_name in lang_wb.sheetnames:

--- a/gui/file_processor_app.py
+++ b/gui/file_processor_app.py
@@ -298,7 +298,7 @@ class FileProcessorApp(QWidget):
         try:
             self.collect_confirmation_changes()
             self.go_to_progress_page()
-            file_to_column = {os.path.basename(k): v for k, v in self.file_to_column.items()} if self.file_to_column else {}
+            file_to_column = self.file_to_column if self.file_to_column else {}
             folder_to_column = {os.path.basename(k): v for k, v in self.folder_to_column.items()} if self.folder_to_column else {}
             folder_path = self.folder_path if folder_to_column else ''
 


### PR DESCRIPTION
### Motivation
- The copy routine failed to paste translations when users dragged one or more Excel files (file-based inputs) because mappings were normalized to basenames and paths were lost. 
- Sheet mapping also assumed exact keys equal to the provided file_path, which broke when mappings were stored under different path variants. 

### Description
- Preserve full file keys for `file_to_column` when starting the copy flow so dropped files are passed to the processor as provided (`gui/file_processor_app.py`).
- Resolve `file_path` in `ExcelProcessor.copy_data` by using the provided name as-is and only joining with `folder_path` when needed, allowing both absolute and relative file entries (`core/excel_processor.py`).
- Improve `_find_matching_sheet` to try multiple lookup keys (`file_path`, `os.path.abspath(file_path)`, and `os.path.basename(file_path)`) when resolving sheet name mappings (`core/excel_processor.py`).

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef9aecbe4832ca005b14a415b2914)