### PR TITLE
Include target Excel in preview file list

### DIFF
--- a/gui/excel_file_selector.py
+++ b/gui/excel_file_selector.py
@@ -72,8 +72,6 @@ class ExcelFileSelector(QDialog):
                 for file in files
                 if file.lower().endswith(('.xlsx', '.xls'))
             ]
-        if self.target_excel:
-            files = [f for f in files if os.path.abspath(f) != os.path.abspath(self.target_excel)]
         return sorted(files)
 
     def add_file_to_list(self, file_path):


### PR DESCRIPTION
### Motivation
- The preview selector should allow the user to open the chosen target Excel file in addition to other translation files.
- Previously the preview dialog filtered out the `target_excel`, preventing it from being opened from the list.

### Description
- Updated `gui/excel_file_selector.py` to stop excluding the `target_excel` from the results returned by `get_excel_files` so the target file remains in the preview list.
- The `get_excel_files` function still filters by Excel extensions and returns a sorted list.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f0852db10832c91e3f059b6741c32)