### PR TITLE
Fix preview window crash and remove target label from preview selector

### DIFF
--- a/core/main_page_logic.py
+++ b/core/main_page_logic.py
@@ -105,7 +105,11 @@ class MainPageLogic(QObject):
                     self.preview_window.activateWindow()
                     self.preview_window.raise_()
                 else:
-                    self.preview_window = ExcelPreviewer(selected_file)
+                    preview_window = ExcelPreviewer(selected_file)
+                    if preview_window is None:
+                        QMessageBox.critical(self.ui, "Ошибка", "Не удалось открыть окно превью.")
+                        return
+                    self.preview_window = preview_window
                     self.preview_window.destroyed.connect(self._clear_preview_window)
                     self.preview_window.show()
 

--- a/gui/excel_file_selector.py
+++ b/gui/excel_file_selector.py
@@ -18,7 +18,6 @@ class ExcelFileSelector(QDialog):
         self.setWindowTitle(self.tr("Превью Excel"))
         layout = QVBoxLayout()
 
-        layout.addWidget(self.create_target_label())
         layout.addWidget(QLabel(self.tr("Загруженные Excel-файлы:")))
         self.file_list = self.create_file_list_widget()
         layout.addWidget(self.file_list)
@@ -29,16 +28,6 @@ class ExcelFileSelector(QDialog):
         self.setLayout(layout)
         self.setGeometry(300, 300, 400, 300)
         self.setModal(True)
-
-    def create_target_label(self):
-        target_label = QLabel(self)
-        target_name = self.tr("(не выбрано)")
-        if self.target_excel:
-            target_name = os.path.basename(self.target_excel)
-        target_label.setText(f"{self.tr('Целевой Excel:')} {target_name}")
-        if self.target_excel:
-            target_label.setToolTip(self.target_excel)
-        return target_label
 
     def create_file_list_widget(self):
         """Создание QListWidget для отображения файлов."""


### PR DESCRIPTION
### Motivation
- Prevent an AttributeError when opening the preview if the preview widget creation fails. 
- Avoid showing a redundant "target Excel" label in the preview selector since the list already marks the target file. 

### Description
- In `on_preview_clicked` (in `core/main_page_logic.py`) instantiate the preview as a local `preview_window`, check it for `None`, and show an error `QMessageBox` if creation failed before assigning to `self.preview_window` and connecting the `destroyed` signal. 
- Keep the existing behavior of reusing an already-visible preview window via `load_file`, `activateWindow` and `raise_`. 
- Removed the `create_target_label` method and its call from `gui/excel_file_selector.py` to eliminate the redundant target Excel label in the selector dialog. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f0dab2a00832cbe8a95276c73ea79)