### PR TITLE
Fix preview window cleanup race

### DIFF
--- a/core/main_page_logic.py
+++ b/core/main_page_logic.py
@@ -110,11 +110,12 @@ class MainPageLogic(QObject):
                         QMessageBox.critical(self.ui, "Ошибка", "Не удалось открыть окно превью.")
                         return
                     self.preview_window = preview_window
-                    self.preview_window.destroyed.connect(self._clear_preview_window)
+                    preview_window.destroyed.connect(self._clear_preview_window)
                     self.preview_window.show()
 
-    def _clear_preview_window(self):
-        self.preview_window = None
+    def _clear_preview_window(self, destroyed_obj=None):
+        if destroyed_obj is None or destroyed_obj == self.preview_window:
+            self.preview_window = None
 
     def update_process_button_state(self):
         source_files = self._collect_source_files()


### PR DESCRIPTION
### Motivation
- Prevent a crash that occurred when opening a second preview which raised `AttributeError: 'NoneType' object has no attribute 'destroyed'`.
- Avoid racing between the `destroyed` signal handler and creation of a new preview window which could clear the new instance.
- Ensure the preview lifecycle is handled robustly when switching files in the previewer.

### Description
- Use the local `preview_window` variable when connecting the `destroyed` signal instead of referencing `self.preview_window` to avoid a `NoneType` access.  
- Change `_clear_preview_window` signature to accept an optional `destroyed_obj` parameter and only clear `self.preview_window` when the destroyed object is `None` or equals the current `self.preview_window`.  
- This guards against wiping a newly created preview window if an old window emits `destroyed` after reassignment.  

### Testing
- No automated tests were run for this change.  
- Manual reproduction steps (from the report) should now no longer raise the `NoneType` exception when opening multiple previews.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f0f411e38832cafab4ce7b75b66f0)