### PR TITLE
Guard copy-column signal hookup for non-Qt entries

### DIFF
--- a/core/main_page_logic.py
+++ b/core/main_page_logic.py
@@ -28,7 +28,8 @@ class MainPageLogic(QObject):
         self.ui.filesSelected.connect(self.on_files_selected)
         self.ui.excelFileSelected.connect(self.on_excel_file_selected)
         self.ui.previewTriggered.connect(self.on_preview_clicked)
-        self.ui.copy_column_entry.textChanged.connect(self.on_copy_column_changed)
+        if hasattr(self.ui.copy_column_entry, "textChanged"):
+            self.ui.copy_column_entry.textChanged.connect(self.on_copy_column_changed)
 
         self.ui.sheet_list.clear()
         self.update_process_button_state()


### PR DESCRIPTION
### Motivation
- Prevent `AttributeError` during initialization when `copy_column_entry` test doubles do not expose a `textChanged` signal.
- Make `MainPageLogic` more robust to lightweight UI stubs used in unit tests or alternative UI implementations.

### Description
- Add a guard around the signal hookup: check `hasattr(self.ui.copy_column_entry, "textChanged")` before connecting to `on_copy_column_changed` in `core/main_page_logic.py`.
- No other runtime behavior is changed and existing signal wiring remains intact for real Qt widgets.

### Testing
- Before this change a test run with `pytest` executed 17 tests and recorded 16 passed and 1 failed (`tests/test_main_page_logic_validation.py::test_main_page_logic_validation`) due to the missing `textChanged` attribute.
- No automated test run has been executed after this change in the rollout transcript.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f957dba3c832ca0272ade938aea63)